### PR TITLE
1.3.10 update, remove spamming output message

### DIFF
--- a/AutoTrader/src/AutoTraderConfig.cs
+++ b/AutoTrader/src/AutoTraderConfig.cs
@@ -11,7 +11,7 @@ namespace AutoTrader
     {
         private static PlatformFilePath _configFile;
 
-        public static string AutoTraderGameVersion { get; } = "v1.3.9";
+        public static string AutoTraderGameVersion { get; } = "v1.3.10";
 
         public static int MaxKeepGrainsValue { get; set; } = 500;
 

--- a/AutoTrader/src/AutoTraderLogic.cs
+++ b/AutoTrader/src/AutoTraderLogic.cs
@@ -86,16 +86,6 @@ namespace AutoTrader
                     "I instructed to load them on our carts but you may want to rethink your orders.").ToString()
                 );
             }
-            else if (_availableInventoryCapacity < 0)
-            {
-                string msgBody = "{=ATNoInventorySpace}My Lord! We cannot fit any more goods into our inventory!";
-                if (AutoTraderConfig.UseMaxFleetCapacityValue)
-                {
-                    msgBody = "{=ATNoFleetSpace}My Lord! We cannot load more goods onto our fleet! Keep in mind that we need space for our herd.";
-                }
-
-                AutoTraderHelpers.PrintMessage(new TextObject(msgBody).ToString());
-            }
         }
 
         private void Sell()

--- a/AutoTrader/src/AutoTraderSubModule.cs
+++ b/AutoTrader/src/AutoTraderSubModule.cs
@@ -34,7 +34,11 @@ namespace AutoTrader
 				+ t_text
 				+ new TextObject("{=ATStartup02}> to open the settings menu", null).ToString());
 
-			string version = ApplicationVersion.FromParametersFile(null).ToString().Substring(0, 7);
+			string fullVersion = ApplicationVersion.FromParametersFile(null).ToString();
+		string[] versionParts = fullVersion.Split('.');
+		string version = versionParts.Length >= 3 
+			? $"{versionParts[0]}.{versionParts[1]}.{versionParts[2]}" 
+			: fullVersion;
 
 			if (!version.Equals(AutoTraderConfig.AutoTraderGameVersion)){
 				AutoTraderHelpers.PrintMessage(new TextObject("{=ATVersionMismatch01}You are using AutoTrader for ", null).ToString()

--- a/AutoTrader/src/AutoTraderSubModule.cs
+++ b/AutoTrader/src/AutoTraderSubModule.cs
@@ -34,7 +34,7 @@ namespace AutoTrader
 				+ t_text
 				+ new TextObject("{=ATStartup02}> to open the settings menu", null).ToString());
 
-			string version = ApplicationVersion.FromParametersFile(null).ToString().Substring(0, 6);
+			string version = ApplicationVersion.FromParametersFile(null).ToString().Substring(0, 7);
 
 			if (!version.Equals(AutoTraderConfig.AutoTraderGameVersion)){
 				AutoTraderHelpers.PrintMessage(new TextObject("{=ATVersionMismatch01}You are using AutoTrader for ", null).ToString()

--- a/AutoTrader/src/AutoTraderSubModule.cs
+++ b/AutoTrader/src/AutoTraderSubModule.cs
@@ -35,10 +35,10 @@ namespace AutoTrader
 				+ new TextObject("{=ATStartup02}> to open the settings menu", null).ToString());
 
 			string fullVersion = ApplicationVersion.FromParametersFile(null).ToString();
-		string[] versionParts = fullVersion.Split('.');
-		string version = versionParts.Length >= 3 
-			? $"{versionParts[0]}.{versionParts[1]}.{versionParts[2]}" 
-			: fullVersion;
+			string[] versionParts = fullVersion.Split('.');
+			string version = versionParts.Length >= 3 
+				? $"{versionParts[0]}.{versionParts[1]}.{versionParts[2]}" 
+				: fullVersion;
 
 			if (!version.Equals(AutoTraderConfig.AutoTraderGameVersion)){
 				AutoTraderHelpers.PrintMessage(new TextObject("{=ATVersionMismatch01}You are using AutoTrader for ", null).ToString()

--- a/AutoTrader/src/SubModule.xml
+++ b/AutoTrader/src/SubModule.xml
@@ -2,19 +2,15 @@
 <Module>
 	<Name value = "AutoTrader"/>
 	<Id value = "AutoTrader"/>
-	<Version value = "v1.3.9.3"/>
+	<Version value = "v1.3.10"/>
 	<SingleplayerModule value="true"/>
 	<MultiplayerModule value="false"/>
 	<Official value="false"/>
 	<DependedModules>
     <DependedModule
       Id="Native"
-      DependentVersion="v1.3.9"
+      DependentVersion="v1.3.10"
       Optional="false" />
-    <DependedModule
-      Id="NavalDLC"
-      DependentVersion="v1.0.5"
-      Optional="true" />
 	</DependedModules>
 	<SubModules>
 		<SubModule>


### PR DESCRIPTION
User reported the new warning spams in some cases, remove for now until theres a better solution.

Also support version comparison for versions with 7 digits. A catch-all solution would be better but I needed a quick fix.